### PR TITLE
Fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import codecs
 from setuptools import setup, find_packages
 
 
-install_deps = ['napari==0.4.7',
+install_deps = ['napari',
                 'napari-plugin-engine>=0.1.4',
                 'cellpose>0.6.3',
                 'imagecodecs']

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,4 @@
-from cellpose_napari import napari_experimental_provide_dock_widget, napari_provide_sample_data
+import cellpose_napari
 import pytest
 
 # this is your plugin name declared in your napari.plugins entry point
@@ -8,13 +8,15 @@ MY_WIDGET_NAMES = ["cellpose"]
 
 
 @pytest.mark.parametrize("widget_name", MY_WIDGET_NAMES)
-def test_something_with_viewer(widget_name, make_napari_viewer):
-   viewer = make_napari_viewer()
-   num_dw = len(viewer.window._dock_widgets)
-   viewer.window.add_plugin_dock_widget(
-       plugin_name=MY_PLUGIN_NAME, widget_name=widget_name
-   )
-   assert len(viewer.window._dock_widgets) == num_dw + 1
+def test_something_with_viewer(widget_name, make_napari_viewer, napari_plugin_manager):
+    napari_plugin_manager.register(cellpose_napari, name=MY_PLUGIN_NAME)
+
+    viewer = make_napari_viewer()
+    num_dw = len(viewer.window._dock_widgets)
+    viewer.window.add_plugin_dock_widget(
+        plugin_name=MY_PLUGIN_NAME, widget_name=widget_name
+    )
+    assert len(viewer.window._dock_widgets) == num_dw + 1
 
 #@pytest.mark.parametrize("widget_name", MY_WIDGET_NAMES)
 #def test_sample_data_with_viewer(widget_name, make_napari_viewer):


### PR DESCRIPTION
Sorry for the breakage @carsen-stringer.  This was a change in the `make_napari_viewer` pytest fixture used in the tests.  It now requires explicitly registering plugins.  Changes made here and napari unpinned. 