### PR TITLE
Delay importing cellpose

### DIFF
--- a/cellpose_napari/_dock_widget.py
+++ b/cellpose_napari/_dock_widget.py
@@ -16,12 +16,6 @@ from napari.layers import Image, Shapes
 from napari_plugin_engine import napari_hook_implementation
 from magicgui import magicgui, magic_factory
 
-from cellpose import models
-from cellpose.utils import masks_to_outlines, fill_holes_and_remove_small_masks
-from cellpose.dynamics import get_masks
-from cellpose.transforms import resize_image
-
-from cellpose import logger
 #import logging
 
 #logger, log_file = logger_setup()
@@ -67,6 +61,14 @@ cp_strings = ['_cp_masks_', '_cp_outlines_', '_cp_flows_', '_cp_cellprob_']
 
 def widget_wrapper():
     from napari.qt.threading import thread_worker
+
+    # Import when users activate plugin
+    from cellpose import models
+    from cellpose.utils import masks_to_outlines, fill_holes_and_remove_small_masks
+    from cellpose.dynamics import get_masks
+    from cellpose.transforms import resize_image
+
+    from cellpose import logger
     
     @thread_worker
     def run_cellpose(image, model_type, custom_model, channels, channel_axis, diameter,

--- a/cellpose_napari/_sample_data.py
+++ b/cellpose_napari/_sample_data.py
@@ -1,7 +1,9 @@
-import pathlib
 import os
-from napari_plugin_engine import napari_hook_implementation
+import pathlib
+from functools import partial
+
 from napari.utils.translations import trans
+from napari_plugin_engine import napari_hook_implementation
 
 CELLPOSE_DATA = [
     ('rgb_3D.tif', trans._('Cells (3D+2Ch)')),
@@ -9,6 +11,10 @@ CELLPOSE_DATA = [
 ]
 
 def _load_cellpose_data(image_name, dname):
+    # Import when users select one of sample data
+    from cellpose.io import imread
+    from cellpose.utils import download_url_to_file
+
     cp_dir = pathlib.Path.home().joinpath('.cellpose')
     cp_dir.mkdir(exist_ok=True)
     data_dir = cp_dir.joinpath('data')
@@ -29,12 +35,6 @@ def _load_cellpose_data(image_name, dname):
 
 @napari_hook_implementation
 def napari_provide_sample_data():
-    from functools import partial
-
-    # Import when users activate plugin
-    from cellpose.utils import download_url_to_file
-    from cellpose.io import imread
-
     return {
         key: {'data': partial(_load_cellpose_data, key, dname), 'display_name': dname}
         for (key, dname) in CELLPOSE_DATA

--- a/cellpose_napari/_sample_data.py
+++ b/cellpose_napari/_sample_data.py
@@ -2,8 +2,6 @@ import pathlib
 import os
 from napari_plugin_engine import napari_hook_implementation
 from napari.utils.translations import trans
-from cellpose.utils import download_url_to_file
-from cellpose.io import imread
 
 CELLPOSE_DATA = [
     ('rgb_3D.tif', trans._('Cells (3D+2Ch)')),
@@ -32,9 +30,13 @@ def _load_cellpose_data(image_name, dname):
 @napari_hook_implementation
 def napari_provide_sample_data():
     from functools import partial
+
+    # Import when users activate plugin
+    from cellpose.utils import download_url_to_file
+    from cellpose.io import imread
+
     return {
         key: {'data': partial(_load_cellpose_data, key, dname), 'display_name': dname}
         for (key, dname) in CELLPOSE_DATA
     }
 
-    


### PR DESCRIPTION
Thanks for making a cellpose plugin. I realized that importing cellpose is called every time napari is launched even when I do not need it. As a result it slows down launching napari. This change simply moves importing inside napari hooks. 


> Preparing cellpose slows down launching napari. In particular,
> downloading models blocks launching napari. This issue may not occur if
> users install cellpose through Plugins menubar. Also, this commit
> prevents initializing cellpose logger everytime napari is launched.