### PR TITLE
Exclude tests from packaged files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,8 @@ test = pytest
 [options.package_data]
 cellpose_napari = napari.yaml
 
+[options.packages.find]
+exclude =
+    tests
+    tests.*
+


### PR DESCRIPTION
A top-level tests package is usually a bad idea since it can be clobbered with other (mispackaged) distributions. If you want to distribute tests, they should be included within the main namespace of the package.

I am patching this as part of the review for the conda-forge submission at https://github.com/conda-forge/staged-recipes/pull/17854.

Thanks!