### PR TITLE
Set upper bound on cellpose to 0.7.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 install_requires = 
 	napari
 	napari-plugin-engine>=0.1.4
-	cellpose>0.6.3
+	cellpose>0.6.3, <=0.7.2
 	imagecodecs
 include_package_data = True
 python_requires = >=3.7


### PR DESCRIPTION
This is a fix for https://github.com/MouseLand/cellpose-napari/issues/21
It's a bummer that cellpose-napari installs fine from the napari plugin GUI, but then doesn't run because the current cellpose version isn't compatible.
By setting an upper bound, the plugin will work until a new version of the plugin can be developed to account for the breaking changes in current cellpose versions.