### PR TITLE
Swap 3D sample from ZCYZ to CZYX

### DIFF
--- a/cellpose_napari/_sample_data.py
+++ b/cellpose_napari/_sample_data.py
@@ -12,6 +12,7 @@ CELLPOSE_DATA = [
 
 def _load_cellpose_data(image_name, dname):
     # Import when users select one of sample data
+    import numpy as np
     from cellpose.io import imread
     from cellpose.utils import download_url_to_file
 
@@ -31,7 +32,12 @@ def _load_cellpose_data(image_name, dname):
         cached_file = str(data_dir_3D.joinpath(image_name))
     if not os.path.exists(cached_file):
         download_url_to_file(url, cached_file, progress=True)
-    return [(imread(cached_file), {'name': dname})]
+    if '3D' in image_name:
+        data = imread(cached_file)
+        data = np.moveaxis(data, 0, 1)
+        return [(data, {'name': dname})]
+    else:
+        return [(imread(cached_file), {'name': dname})]
 
 _DATA = {
     key: {'data': partial(_load_cellpose_data, key, dname), 'display_name': dname}

--- a/cellpose_napari/_sample_data.py
+++ b/cellpose_napari/_sample_data.py
@@ -32,12 +32,10 @@ def _load_cellpose_data(image_name, dname):
         cached_file = str(data_dir_3D.joinpath(image_name))
     if not os.path.exists(cached_file):
         download_url_to_file(url, cached_file, progress=True)
+    data = imread(cached_file)
     if '3D' in image_name:
-        data = imread(cached_file)
         data = np.moveaxis(data, 0, 1)
-        return [(data, {'name': dname})]
-    else:
-        return [(imread(cached_file), {'name': dname})]
+    return [(data, {'name': dname})]
 
 _DATA = {
     key: {'data': partial(_load_cellpose_data, key, dname), 'display_name': dname}


### PR DESCRIPTION
Fixes issue noted here: https://github.com/MouseLand/cellpose-napari/pull/28#issuecomment-1146672346
Previously, the sample image was loaded as ZCYX, which led to strange labeling (even with `process stack as 3D`)
By changing the sample to CZYX, the labeling is visually correct: the labels layer has the proper shape and 3D rendering also works correctly.