### PR TITLE
FIx Windows OpenGL test failure

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,8 +37,10 @@ jobs:
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
+          if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
+
 
       # note: if you need dependencies from conda, considering using
       # setup-miniconda: https://github.com/conda-incubator/setup-miniconda
@@ -50,7 +52,9 @@ jobs:
           pip install setuptools tox tox-gh-actions
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        run: tox
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
 


### PR DESCRIPTION
Trying to fix Windows tests due to OpenGL install failure:
https://github.com/MouseLand/cellpose-napari/runs/6759900889?check_suite_focus=true
Copy-pasta from plugins that have working tests and napari workflows.