### PR TITLE
Bugfix: pass image_layer.scale to the newly created layers

### DIFF
--- a/cellpose_napari/_dock_widget.py
+++ b/cellpose_napari/_dock_widget.py
@@ -201,11 +201,11 @@ def widget_wrapper():
             widget.iseg = '_' + '%03d'%len(widget.cellpose_layers)
             layers = []
             if widget.output_flows.value:
-                layers.append(viewer.add_image(flows, name=image_layer.name + '_cp_flows' + widget.iseg, visible=False, rgb=True))
-                layers.append(viewer.add_image(cellprob, name=image_layer.name + '_cp_cellprob' + widget.iseg, visible=False))
+                layers.append(viewer.add_image(flows, name=image_layer.name + '_cp_flows' + widget.iseg, visible=False, rgb=True, scale=image_layer.scale))
+                layers.append(viewer.add_image(cellprob, name=image_layer.name + '_cp_cellprob' + widget.iseg, visible=False, scale=image_layer.scale))
             if widget.output_outlines.value:
-                layers.append(viewer.add_labels(outlines, name=image_layer.name + '_cp_outlines' + widget.iseg, visible=False))
-            layers.append(viewer.add_labels(masks, name=image_layer.name + '_cp_masks' + widget.iseg, visible=False))
+                layers.append(viewer.add_labels(outlines, name=image_layer.name + '_cp_outlines' + widget.iseg, visible=False, scale=image_layer.scale))
+            layers.append(viewer.add_labels(masks, name=image_layer.name + '_cp_masks' + widget.iseg, visible=False, scale=image_layer.scale))
             widget.cellpose_layers.append(layers)
 
         def _new_segmentation(segmentation):

--- a/cellpose_napari/_dock_widget.py
+++ b/cellpose_napari/_dock_widget.py
@@ -200,12 +200,19 @@ def widget_wrapper():
             widget.masks_orig = masks
             widget.iseg = '_' + '%03d'%len(widget.cellpose_layers)
             layers = []
+
+            # get physical scale (...ZYX)
+            if len(image_layer.scale) > 3:
+                physical_scale = image_layer.scale[-3:]
+            else:
+                physical_scale = image_layer.scale
+            
             if widget.output_flows.value:
-                layers.append(viewer.add_image(flows, name=image_layer.name + '_cp_flows' + widget.iseg, visible=False, rgb=True, scale=image_layer.scale))
-                layers.append(viewer.add_image(cellprob, name=image_layer.name + '_cp_cellprob' + widget.iseg, visible=False, scale=image_layer.scale))
+                layers.append(viewer.add_image(flows, name=image_layer.name + '_cp_flows' + widget.iseg, visible=False, rgb=True, scale=physical_scale))
+                layers.append(viewer.add_image(cellprob, name=image_layer.name + '_cp_cellprob' + widget.iseg, visible=False, scale=physical_scale))
             if widget.output_outlines.value:
-                layers.append(viewer.add_labels(outlines, name=image_layer.name + '_cp_outlines' + widget.iseg, visible=False, scale=image_layer.scale))
-            layers.append(viewer.add_labels(masks, name=image_layer.name + '_cp_masks' + widget.iseg, visible=False, scale=image_layer.scale))
+                layers.append(viewer.add_labels(outlines, name=image_layer.name + '_cp_outlines' + widget.iseg, visible=False, scale=physical_scale))
+            layers.append(viewer.add_labels(masks, name=image_layer.name + '_cp_masks' + widget.iseg, visible=False, scale=physical_scale))
             widget.cellpose_layers.append(layers)
 
         def _new_segmentation(segmentation):


### PR DESCRIPTION
This is a fix for issue: https://github.com/MouseLand/cellpose-napari/issues/37
On live, try this to open the sample 2D image, set a scale, and then run the plugin with default settings:
`viewer.add_image(_load_cellpose_data('rgb_2D.png', 'Cells 2D')[0][0], scale=(.5, .5))` 
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/76622105/186022016-fee0feb9-d96b-4e39-8cec-3cffe0cf2588.png">
Clearly the labels et al, having inherited the scale.
Using this PR, the `scale` value of the image layer being segmented is passed to the created layers:
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/76622105/186022194-1c7f669b-13ce-4dd1-9252-eb60bd3e0593.png">
