### PR TITLE
Extend test timeouts (mostly for macOS)

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -42,7 +42,7 @@ def test_basic_function(qtbot, viewer_widget):
     def check_widget():
         assert widget.cellpose_layers
 
-    qtbot.waitUntil(check_widget, timeout=30_000)
+    qtbot.waitUntil(check_widget, timeout=60_000)
     # check that the layers were created properly
     assert len(viewer.layers) == 5
     assert "cp_masks" in viewer.layers[-1].name
@@ -79,7 +79,7 @@ def test_3D_segmentation(qtbot,  viewer_widget):
     def check_widget():
         assert widget.cellpose_layers
 
-    qtbot.waitUntil(check_widget, timeout=90_000)
+    qtbot.waitUntil(check_widget, timeout=120_000)
     # check that the layers were created properly
     assert len(viewer.layers) == 5
     assert "cp_masks" in viewer.layers[-1].name


### PR DESCRIPTION
The 3D segmentation test on macOS seems to be around 80 s pretty consistently, so easy to hiccup and hit over 90:
https://github.com/MouseLand/cellpose-napari/pull/39#issuecomment-1228915686
Bumping the other one to 60s just to be safe.