### PR TITLE
[maint] Fix CI (GitHub actions workflow and tox.ini)

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -17,6 +17,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.platform }} ${{ matrix.python-version }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,9 +25,6 @@ jobs:
   test:
     name: ${{ matrix.platform }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
-    defaults:
-      run:
-        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +55,6 @@ jobs:
       - name: Test with tox
         uses: aganders3/headless-gui@v2
         with:
-          shell: bash -el {0}
           run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -37,12 +37,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-          channels: conda-forge
-          channel-priority: strict
-          python-version: ${{ matrix.python-version }}
 
       - uses: tlambert03/setup-qt-libs@v1
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -38,6 +38,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install Windows OpenGL

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest]#, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         backend: [pyqt5]
 
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        backend: [pyqt5]
 
     steps:
       - uses: actions/checkout@v4
@@ -57,15 +56,12 @@ jobs:
           python -m pip install --upgrade setuptools tox tox-gh-actions
 
       - name: Test with tox
-        uses: aganders3/headless-gui@v1.2
+        uses: aganders3/headless-gui@v2
         with:
           shell: bash -el {0}
           run: python -m tox
         env:
           PLATFORM: ${{ matrix.platform }}
-          PYTHON: ${{ matrix.python-version }}
-          PYVISTA_OFF_SCREEN: True
-          BACKEND: ${{ matrix.backend }}
 
       - name: Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools tox tox-conda tox-gh-actions
+          python -m pip install --upgrade setuptools tox tox-gh-actions
 
       - name: Test with tox
         uses: aganders3/headless-gui@v1.2

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,6 +17,13 @@ WIDGET_NAME = "cellpose"
 
 SAMPLE = Path(__file__).parent / "sample.tif"
 
+@pytest.fixture(autouse=True)
+def patch_mps_on_CI(monkeypatch):
+    # https://github.com/actions/runner-images/issues/9918
+    if os.getenv('CI'):
+        monkeypatch.setattr("torch.backends.mps.is_available", lambda: False)
+
+
 @pytest.fixture
 def viewer_widget(make_napari_viewer: Callable[..., napari.Viewer]):
     viewer = make_napari_viewer()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -22,7 +22,7 @@ def patch_mps_on_CI(monkeypatch):
     # https://github.com/actions/runner-images/issues/9918
     if os.getenv('CI'):
         monkeypatch.setattr("torch.backends.mps.is_available", lambda: False)
-        monkeypatch.setattr("cellpose.core.assign_device", lambda: (torch.device("cpu"), False))
+        monkeypatch.setattr("cellpose.core.assign_device", lambda **kwargs: (torch.device("cpu"), False))
 
 
 @pytest.fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -71,7 +71,9 @@ def test_compute_diameter(qtbot, viewer_widget):
     with qtbot.waitSignal(widget.diameter.changed, timeout=60_000) as blocker:
         widget.compute_diameter_button.changed(None)
 
-    assert isclose(float(widget.diameter.value), 24.1, abs_tol=10**-1)
+    # local on macOS with MPS, get 20.37, with CPU-only it's 20.83, same as CI
+    # so choosing a target that works for both
+    assert isclose(float(widget.diameter.value), 20.6, abs_tol=0.3)
 
 @pytest.mark.skipif(sys.platform.startswith('linux'), reason="ubuntu stalls with >1 cellpose tests")
 def test_3D_segmentation(qtbot,  viewer_widget):
@@ -80,7 +82,7 @@ def test_3D_segmentation(qtbot,  viewer_widget):
 
     # set 3D processing
     widget.process_3D.value = True
-
+    widget.model_choice.value = "cyto3"
     widget()  # run segmentation with all default parameters
 
     def check_widget():
@@ -91,5 +93,5 @@ def test_3D_segmentation(qtbot,  viewer_widget):
     assert len(viewer.layers) == 5
     assert "cp_masks" in viewer.layers[-1].name
 
-    # check that the segmentation was proper, should yield 7 cells
-    assert viewer.layers[-1].data.max() == 7
+    # check that the segmentation was proper, `cyto3` should yield 9 cells
+    assert viewer.layers[-1].data.max() == 9

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,14 +1,11 @@
 import os
-import sys
 from pathlib import Path
 from math import isclose
 from typing import Callable
 
-import cellpose_napari
 import napari
 import pytest
 import torch # for ubuntu tests on CI, see https://github.com/pytorch/pytorch/issues/75912
-from cellpose_napari._dock_widget import widget_wrapper
 
 # this is your plugin name declared in your napari.plugins entry point
 PLUGIN_NAME = "cellpose-napari"
@@ -40,11 +37,7 @@ def test_basic_function(qtbot, viewer_widget):
     viewer.open_sample(PLUGIN_NAME, 'rgb_2D')
     viewer.layers[0].data = viewer.layers[0].data[0:128, 0:128]
 
-    #if os.getenv("CI"):
-    #    return
-        # actually running cellpose like this takes too long and always timesout on CI
-        # need to figure out better strategy
-
+    widget.model_type.value = "cyto3"
     widget()  # run segmentation with all default parameters
 
     def check_widget():
@@ -55,7 +48,7 @@ def test_basic_function(qtbot, viewer_widget):
     assert len(viewer.layers) == 5
     assert "cp_masks" in viewer.layers[-1].name
 
-    # check that the segmentation was proper, should yield 11 cells
+    # check that the segmentation was proper, cyto3 yields 10 cells
     assert viewer.layers[-1].data.max() == 10
 
 def test_compute_diameter(qtbot, viewer_widget):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -22,6 +22,7 @@ def patch_mps_on_CI(monkeypatch):
     # https://github.com/actions/runner-images/issues/9918
     if os.getenv('CI'):
         monkeypatch.setattr("torch.backends.mps.is_available", lambda: False)
+        monkeypatch.setattr("cellpose.core.assign_device", lambda: (torch.device("cpu"), False))
 
 
 @pytest.fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -82,7 +82,7 @@ def test_3D_segmentation(qtbot,  viewer_widget):
 
     # set 3D processing
     widget.process_3D.value = True
-    widget.model_choice.value = "cyto3"
+    widget.model_type.value = "cyto3"
     widget()  # run segmentation with all default parameters
 
     def check_widget():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -58,7 +58,6 @@ def test_basic_function(qtbot, viewer_widget):
     # check that the segmentation was proper, should yield 11 cells
     assert viewer.layers[-1].data.max() == 10
 
-@pytest.mark.skipif(sys.platform.startswith('linux'), reason="ubuntu stalls with two cellpose tests")
 def test_compute_diameter(qtbot, viewer_widget):
     viewer, widget = viewer_widget
     viewer.open_sample(PLUGIN_NAME, 'rgb_2D')
@@ -75,7 +74,6 @@ def test_compute_diameter(qtbot, viewer_widget):
     # so choosing a target that works for both
     assert isclose(float(widget.diameter.value), 20.6, abs_tol=0.3)
 
-@pytest.mark.skipif(sys.platform.startswith('linux'), reason="ubuntu stalls with >1 cellpose tests")
 def test_3D_segmentation(qtbot,  viewer_widget):
     viewer, widget = viewer_widget
     viewer.open_sample(PLUGIN_NAME, 'rgb_3D')

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{39,310,311,312}-{linux,macos,windows}
 isolated_build=true
 toxworkdir = /tmp/.tox
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
     
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
The github action and tox.ini got out of sync with some strange multi-python tox envs:
https://github.com/MouseLand/cellpose-napari/actions/runs/10851583106/job/30115669221?pr=33#step:7:157

In this PR I try to clean up old/unused elements from the github actions workflow and update tox.ini to python 3.9-3.12.
I also add using concurrency so that multiple pushes will cancel tests, rather than piling them up.
I restored macOS, ubuntu, and Windows tests, updating the test suite to specify model cyto3 such that the expected values can be specified. 
I also monkeypatch such that on CI CPU is used. This gives a different diameter value, so I split the difference in the `isclose` so that tests work on CI and locally.
Finally I do some cleanup of imports and comments.
 